### PR TITLE
chore: release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.2](https://github.com/samp-reston/doip-codec/compare/v2.0.1...v2.0.2) - 2025-01-03
+
+### Other
+
+- add release plz workflow
+- set no run on doc test
+- update readme

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-codec"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "Diagnostics over Internet Protocol codec for client-server communication."


### PR DESCRIPTION
## 🤖 New release
* `doip-codec`: 2.0.1 -> 2.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.2](https://github.com/samp-reston/doip-codec/compare/v2.0.1...v2.0.2) - 2025-01-03

### Other

- add release plz workflow
- set no run on doc test
- update readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).