### PR TITLE
chore: release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3](https://github.com/samp-reston/doip-codec/compare/v2.0.2...v2.0.3) - 2025-03-05
+
+### Other
+
+- unused var
+- prepare for python bindings
+- add lib and remove panic
+- remove example usage
+- complete transition to new implementation
+- apply auto clippy features
+- handle error states
+- apply clippy
+- complete implementation
+- add gitlab ci and begin encoder
+- add Docs for decoder
+- reset based on new definitions api
+- begin codec rework
+
 ## [2.0.2](https://github.com/samp-reston/doip-codec/compare/v2.0.1...v2.0.2) - 2025-01-03
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-codec"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "Diagnostics over Internet Protocol codec for client-server communication."


### PR DESCRIPTION



## 🤖 New release

* `doip-codec`: 2.0.2 -> 2.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.3](https://github.com/samp-reston/doip-codec/compare/v2.0.2...v2.0.3) - 2025-03-05

### Other

- unused var
- prepare for python bindings
- add lib and remove panic
- remove example usage
- complete transition to new implementation
- apply auto clippy features
- handle error states
- apply clippy
- complete implementation
- add gitlab ci and begin encoder
- add Docs for decoder
- reset based on new definitions api
- begin codec rework
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).