### PR TITLE
chore: release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5](https://github.com/samp-reston/doip-codec/compare/v2.0.4...v2.0.5) - 2025-03-05
+
+### Fixed
+
+- repair broken encoder impl
+
 ## [2.0.4](https://github.com/samp-reston/doip-codec/compare/v2.0.3...v2.0.4) - 2025-03-05
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-codec"
-version = "2.0.4"
+version = "2.0.5"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "Diagnostics over Internet Protocol codec for client-server communication."


### PR DESCRIPTION
## 🤖 New release
* `doip-codec`: 2.0.4 -> 2.0.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.5](https://github.com/samp-reston/doip-codec/compare/v2.0.4...v2.0.5) - 2025-03-05

### Fixed

- repair broken encoder impl
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).