### PR TITLE
chore: release v2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.6](https://github.com/samp-reston/doip-codec/compare/v2.0.5...v2.0.6) - 2025-05-28
+
+### Other
+
+- complete embedded and non embedded implementation
+- begin rework with better module declarations
+
 ## [2.0.5](https://github.com/samp-reston/doip-codec/compare/v2.0.4...v2.0.5) - 2025-03-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-codec"
-version = "2.0.5"
+version = "2.0.6"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "Diagnostics over Internet Protocol codec for client-server communication."


### PR DESCRIPTION



## 🤖 New release

* `doip-codec`: 2.0.5 -> 2.0.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.6](https://github.com/samp-reston/doip-codec/compare/v2.0.5...v2.0.6) - 2025-05-28

### Other

- complete embedded and non embedded implementation
- begin rework with better module declarations
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).