### PR TITLE
chore: release v2.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.8](https://github.com/samp-reston/doip-codec/compare/v2.0.7...v2.0.8) - 2025-06-26
+
+### Other
+
+- Update doip-defititions dependency to 3.0.12
+- Ensure src.advance does not go out of bounds
+- decouple pyo3 bindings from std featur
+
 ## [2.0.7](https://github.com/samp-reston/doip-codec/compare/v2.0.6...v2.0.7) - 2025-06-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doip-codec"
-version = "2.0.7"
+version = "2.0.8"
 authors = ["Samuel Preston <samp.reston@outlook.com>"]
 edition = "2021"
 description = "Diagnostics over Internet Protocol codec for client-server communication."


### PR DESCRIPTION



## 🤖 New release

* `doip-codec`: 2.0.7 -> 2.0.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.8](https://github.com/samp-reston/doip-codec/compare/v2.0.7...v2.0.8) - 2025-06-26

### Other

- Update doip-defititions dependency to 3.0.12
- Ensure src.advance does not go out of bounds
- decouple pyo3 bindings from std featur
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).